### PR TITLE
FIX: Better context of user displayed error

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,4 +1,4 @@
 en:
   SilverStripe\MimeValidator\MimeUploadValidator:
     FAILEDMIMECHECK: 'MIME validation failed: {message}'
-    INVALIDMIME: 'File extension does not match known MIME type'
+    INVALIDMIME: 'File type does not match extension (.{extension})'

--- a/src/MimeUploadValidator.php
+++ b/src/MimeUploadValidator.php
@@ -150,11 +150,14 @@ class MimeUploadValidator extends Upload_Validator
 
         try {
             $result = $this->isValidMime();
-
             if ($result === false) {
+                $extension = strtolower(pathinfo($this->tmpFile['name'], PATHINFO_EXTENSION));
                 $this->errors[] = _t(
                     __CLASS__ . '.INVALIDMIME',
-                    'File extension does not match known MIME type'
+                    'File type does not match extension (.{extension})',
+                    [
+                        'extension' => $extension,
+                    ]
                 );
 
                 return false;


### PR DESCRIPTION
An end user (content editor) administering an upload via the CMS may not necessarily know what a MIME type is, however the concept of an extension (particularly when provided with the value) should hopefully make the error displayed more understandable to a greater group of persons.

Resolves #33 (https://github.com/silverstripe/silverstripe-mimevalidator/issues/33)