### PR TITLE
Add PHP-8 support for CSV mime type

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,6 +3,9 @@ Name: mimevalidator
 ---
 SilverStripe\MimeValidator\MimeUploadValidator:
   MimeTypes:
+    csv:
+      - 'application/csv'
+      - 'text/plain'
     ico:
       - 'image/vnd.microsoft.icon'
       - 'image/x-icon'


### PR DESCRIPTION
In PHP-8 `finfo()` detects a CSV file as `application/csv` whereas in PHP-7 it is returned as `text/plain`.

This fixes CSV importing via the CMS ModelAdmin.