### PR TITLE
Add support for braille format files

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,6 +3,9 @@ Name: mimevalidator
 ---
 SilverStripe\MimeValidator\MimeUploadValidator:
   MimeTypes:
+    brf:
+      - 'text/plain'
+      - 'application/octet-stream'
     csv:
       - 'application/csv'
       - 'text/plain'


### PR DESCRIPTION
Relates to issue [silverstripe/silverstripe-assets#573](https://github.com/silverstripe/silverstripe-assets/issues/573)
and PR: [silverstripe/silverstripe-framework#10970](https://github.com/silverstripe/silverstripe-framework/pull/10970)

This adds support for the [Braille ASCII file format](https://en.wikipedia.org/wiki/Braille_ASCII).

There is disagreement on what mime type brf files should be: datatypes.net says it should be application/octet-stream ([ref](https://datatypes.net/open-brf-files)), but apache says it should be text/plain ([ref](https://bz.apache.org/bugzilla/show_bug.cgi?id=41240)). 

To be safe I have added both, however `text/plain` is likely to be the most used.

## Issue
- https://github.com/silverstripe/silverstripe-assets/issues/573