### PR TITLE
MNT Remove unused dev-dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
     "require-dev": {
         "phpunit/phpunit": "^11.3",
         "squizlabs/php_codesniffer": "^3.7",
-        "nikic/php-parser": "^4.15.0",
         "monolog/monolog": "^3.2.0",
         "silverstripe/standards": "^1",
         "phpstan/extension-installer": "^1.3"


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-mimevalidator/actions/runs/11061570379/job/30734529021

```text
  Problem 1
    - Root composer.json requires silverstripe/framework ^6 -> satisfiable by silverstripe/framework[6.x-dev].
    - silverstripe/framework 6.x-dev requires nikic/php-parser ^5.1.0 -> found nikic/php-parser[v5.1.0, v5.2.0] but it conflicts with your root composer.json require (^4.15.0).
  Problem 2
    - silverstripe/framework 6.x-dev requires nikic/php-parser ^5.1.0 -> found nikic/php-parser[v5.1.0, v5.2.0] but it conflicts with your root composer.json require (^4.15.0).
    - silverstripe/installer 6.x-dev requires silverstripe/login-forms 6.x-dev -> satisfiable by silverstripe/login-forms[6.x-dev].
    - silverstripe/login-forms 6.x-dev requires silverstripe/framework ^6 -> satisfiable by silverstripe/framework[6.x-dev].
    - Root composer.json requires silverstripe/installer 6.x-dev -> satisfiable by silverstripe/installer[6.x-dev].
```

`nikic/php-parser` dev dependency doesn't seem to even be used, so I've just removed it outright.

## Issue
- https://github.com/silverstripe/.github/issues/313